### PR TITLE
added "repeatTransmit" parameter to codesend

### DIFF
--- a/RPi_utils/codesend.cpp
+++ b/RPi_utils/codesend.cpp
@@ -29,13 +29,15 @@ int main(int argc, char *argv[]) {
     // Parse the first parameter to this command as an integer
     int protocol = 0; // A value of 0 will use rc-switch's default value
     int pulseLength = 0;
+    int repeatTransmit = 0;
 
     // If no command line argument is given, print the help text
     if (argc == 1) {
-        printf("Usage: %s decimalcode [protocol] [pulselength]\n", argv[0]);
+        printf("Usage: %s decimalcode [protocol] [pulselength] [repeatTransmit]\n", argv[0]);
         printf("decimalcode\t- As decoded by RFSniffer\n");
         printf("protocol\t- According to rc-switch definitions\n");
         printf("pulselength\t- pulselength in microseconds\n");
+        printf("repeatTransmit\t- How often to repeat the code. Defaults to 10.\n");
         return -1;
     }
 
@@ -43,12 +45,14 @@ int main(int argc, char *argv[]) {
     int code = atoi(argv[1]);
     if (argc >= 3) protocol = atoi(argv[2]);
     if (argc >= 4) pulseLength = atoi(argv[3]);
+    if (argc >= 5) repeatTransmit = atoi(argv[4]);
     
     if (wiringPiSetup () == -1) return 1;
     printf("sending code[%i]\n", code);
     RCSwitch mySwitch = RCSwitch();
     if (protocol != 0) mySwitch.setProtocol(protocol);
     if (pulseLength != 0) mySwitch.setPulseLength(pulseLength);
+    if (repeatTransmit != 0) mySwitch.setRepeatTransmit(repeatTransmit);
     mySwitch.enableTransmit(PIN);
     
     mySwitch.send(code, 24);


### PR DESCRIPTION
An optional "repeatTransmit" parameter for codesend which gets passed down to rcswitch and tells it how often to repeat sending the signal.

(This is basically a clone of PR #60 which had to be closed for technical reasons.)